### PR TITLE
handling windows-style end-of-lines

### DIFF
--- a/zippyshare.sh
+++ b/zippyshare.sh
@@ -40,7 +40,7 @@ function zippydownload()
 
     # Get cookie
     if [ -f "${cookiefile}" ]
-    then 
+    then
         jsessionid="$( cat "${cookiefile}" | grep "JSESSIONID" | cut -f7)"
     else
         echo "can't find cookie file for ${prefix}"
@@ -88,7 +88,7 @@ function zippydownload()
 
 if [ -f "${1}" ]
 then
-    for url in $( cat "${1}" | grep -i 'zippyshare.com' )
+    for url in $( cat "${1}" | sed 's/\r$//' | grep -i 'zippyshare.com' )
     do
         zippydownload "${url}"
     done


### PR DESCRIPTION
Stumbled on zippyshare index file with windows-style newlines (including `\r`). This minor change helped me.